### PR TITLE
refactor: use refs to track schedule data

### DIFF
--- a/lib/useGtfsSchedule.js
+++ b/lib/useGtfsSchedule.js
@@ -1,22 +1,22 @@
 import { camelCase } from 'change-case'
 import JSZip from 'jszip'
 import Papa from 'papaparse'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import useRefresh from './useRefresh.js'
 
 export default function useGtfsSchedule (resolve, timeout) {
   const rawScheduleData = useRefresh(resolve, timeout)
+  const dataCache = useRef({})
   const [data, setData] = useState(undefined)
   useEffect(() => {
     if (rawScheduleData === undefined) {
       setData(undefined)
     } else {
       JSZip.loadAsync(rawScheduleData).then((zip) => {
-        const cache = { ...data }
         for (const [filename, file] of Object.entries(zip.files)) {
           file.async('text').then(parseCsv).then((json) => {
-            cache[camelCase(removeExtension(filename))] = json
-            setData({ ...cache })
+            dataCache.current[camelCase(removeExtension(filename))] = json
+            setData({ ...dataCache.current })
           })
         }
       })


### PR DESCRIPTION
This is the "proper" way to "track something in the background" - i.e. keep the old values from a schedule resolve while resolving the new values piecemeal
